### PR TITLE
Create Firebase Auth context

### DIFF
--- a/app/firebaseAdmin.js
+++ b/app/firebaseAdmin.js
@@ -1,3 +1,5 @@
+"use client"
+import { getFirestore } from "@firebase/firestore";
 // Import the functions you need from the SDKs you need
 import { initializeApp } from "firebase/app";
 import { getAuth } from "firebase/auth";
@@ -18,3 +20,4 @@ const firebaseConfig = {
 // Initialize Firebase
 const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app);
+export const db = getFirestore(app);

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -8,6 +8,7 @@
       "name": "recycle-app-demo",
       "version": "0.1.0",
       "dependencies": {
+        "@firebase/firestore": "^4.3.2",
         "@fortawesome/fontawesome-svg-core": "^6.4.2",
         "@fortawesome/free-solid-svg-icons": "^6.4.2",
         "@fortawesome/react-fontawesome": "^0.2.0",

--- a/app/package.json
+++ b/app/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@firebase/firestore": "^4.3.2",
     "@fortawesome/fontawesome-svg-core": "^6.4.2",
     "@fortawesome/free-solid-svg-icons": "^6.4.2",
     "@fortawesome/react-fontawesome": "^0.2.0",

--- a/app/src/app/layout.js
+++ b/app/src/app/layout.js
@@ -9,8 +9,9 @@ import { useRouter } from "next/navigation";
 import { createContext, useRef, useState } from "react";
 
 import React, { useEffect } from 'react';
-import { auth } from "../../firebaseAdmin.js";
+import { auth, db } from "../../firebaseAdmin.js";
 import { onAuthStateChanged, signOut } from 'firebase/auth';
+import { FirebaseProvider } from "@/context/FirebaseContext";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -181,6 +182,7 @@ export default function RootLayout({ children }) {
             <body className={inter.className} id="sideMenu">
                 <main className="flex bg-gradient h-full relative max-h-screen overflow-hidden flex-col items-start">
                 <MenuBarContext.Provider value={{toggleMenu}}>
+                    <FirebaseProvider>
                   <div className="z-10 w-full flex flex-col items-center min-h-[100vh] max-h-[100vh] overflow-auto text-sm lg:flex">
                     {children}
                   </div>
@@ -198,6 +200,7 @@ export default function RootLayout({ children }) {
                           Sign Out
                       </button>
                   </div>
+                  </FirebaseProvider>
                 </MenuBarContext.Provider>
                 </main>
             </body>

--- a/app/src/context/FirebaseContext.js
+++ b/app/src/context/FirebaseContext.js
@@ -1,0 +1,33 @@
+"use client"
+import { createContext, useEffect, useLayoutEffect, useState } from "react";
+import { auth, db } from "../../firebaseAdmin";
+import { redirect, usePathname, useRouter } from "next/navigation";
+
+export const FirebaseContext = createContext();
+
+export function FirebaseProvider({children}) {
+    const [user, setUser] = useState(null);
+    const router = useRouter();
+    const pathname = usePathname();
+    // Whenever user is
+    useEffect(() => {
+        return auth.onIdTokenChanged(async (user) => {
+            if (!user) {
+                setUser(null);
+                router.push("/");
+            } else {
+                setUser(user);
+            }
+        })
+    }, [])
+
+    useLayoutEffect(() => {
+    }, [])
+
+    return (
+        <FirebaseContext.Provider value={(user, db, auth)}>
+            {(user || pathname == "/") ? children : <></>}
+        </FirebaseContext.Provider>
+    )
+    
+}


### PR DESCRIPTION
This PR adds a cute little client-side Firebase context that can be used to access information about the currently authenticated user as well as access to db and auth methods. Also redirects user to the login/register page if their auth state is undone.